### PR TITLE
RelayConnectionType injectCursor compatibility with Laravel 5.2

### DIFF
--- a/src/Support/Definition/RelayConnectionType.php
+++ b/src/Support/Definition/RelayConnectionType.php
@@ -133,7 +133,7 @@ class RelayConnectionType extends GraphQLType
         if ($collection instanceof LengthAwarePaginator) {
             $page = $collection->currentPage();
 
-            $collection->each(function ($item, $x) use ($page) {
+            $collection->values()->each(function ($item, $x) use ($page) {
                 $cursor        = ($x + 1) * $page;
                 $encodedCursor = $this->encodeGlobalId('arrayconnection', $cursor);
                 if (is_array($item)) {


### PR DESCRIPTION
As per [the Laravel 5.2 upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0):

> Key Preservation
> 
> The slice, chunk, and reverse methods now preserve keys on the collection. If you do not want these methods to preserve keys, use the values method on the Collection instance.

RelayConnectionType->injectCursor($collection) was broken in Laravel 5.2, not generating a properly sequenced cursor when using pagination.
